### PR TITLE
Updated typo for remove function

### DIFF
--- a/BingMaps/v8-web-control/map-control-api/customoverlay-class.md
+++ b/BingMaps/v8-web-control/map-control-api/customoverlay-class.md
@@ -57,7 +57,7 @@ MyCustomOverlay.prototype.onLoad = function () {
     //Logic to perform after overlay has been added to the map.
 };
 
-MyCustomOverlay.prototype.onAdd = function () {
+MyCustomOverlay.prototype.onRemove = function () {
     //Logic to perform when overlay has been removed from the map.
 };
 


### PR DESCRIPTION
In the code example, the wrong name was used. Should be `onRemove`.