### PR TITLE
Remove duplicate key 'maintainContext'

### DIFF
--- a/BingMaps/rest-services/toc.yml
+++ b/BingMaps/rest-services/toc.yml
@@ -135,7 +135,6 @@
         href: common-parameters-and-types/supported-culture-codes.md
       - name: Location Recognition Entity Types
         href: common-parameters-and-types/location-and-recognition-entity-types.md
-    maintainContext: true
   - name: Common Response Description
     href: common-response-description.md
   - name: JSON Data Contracts


### PR DESCRIPTION
In this [commit](https://github.com/MicrosoftDocs/bingmaps-docs/commit/145ab0b54b91ccd6e6abc9cde920400b1286789f#diff-9198e74bdcc1f7cdf8253399c3cb46d4), the key `maintainContext` didn't removed with item `API Reference`, which causing the key `maintainContext` duplicate in item `Common Parameters and Types`.

We created this pull request to resolve above issue and unblock v3 migration.