### PR TITLE
Fixed Incorrect Example for Bounds in Get Elevations

### DIFF
--- a/BingMaps/rest-services/elevations/get-elevations.md
+++ b/BingMaps/rest-services/elevations/get-elevations.md
@@ -48,7 +48,7 @@ http://dev.virtualearth.net/REST/v1/Elevation/Polyline?points={lat1,long1,lat2,l
 The parameters `bounds`, `rows`, `cols`, and `key` are required.
   
 ```url
-http://dev.virtualearth.net/REST/v1/Elevation/{Bounds}?bounds={boundingBox}&rows={rows}&cols={cols}&heights={heights}&key={BingMapsAPIKey}  
+http://dev.virtualearth.net/REST/v1/Elevation/Bounds?bounds={boundingBox}&rows={rows}&cols={cols}&heights={heights}&key={BingMapsAPIKey}  
 ```  
   
 ### Get the offset of the geoid sea level Earth model from the ellipsoid Earth model


### PR DESCRIPTION
With the example, the result back would just be a blank page. Changing `{Bounds}` to `Bounds` fixes it and the request will now work as intended.
`http://dev.virtualearth.net/REST/v1/Elevation/{Bounds}?bounds={boundingBox}&rows={rows}&cols={cols}&heights={heights}&key={BingMapsAPIKey}`