### PR TITLE
Grammatical fix

### DIFF
--- a/BingMaps/includes/get-bing-map-key-note.md
+++ b/BingMaps/includes/get-bing-map-key-note.md
@@ -1,3 +1,3 @@
 > [!Note]
 > These templates support both HTTP and HTTPS protocols.
-> To use this API, you must have a [Getting a Bing Maps Key](../getting-started/bing-maps-dev-center-help/getting-a-bing-maps-key.md).
+> To use this API, you must have a [Bing Maps Key](../getting-started/bing-maps-dev-center-help/getting-a-bing-maps-key.md).


### PR DESCRIPTION
Change:

To use this API, you must have a [Getting a Bing Maps Key](../getting-started/bing-maps-dev-center-help/getting-a-bing-maps-key.md).

to this:

To use this API, you must have a [Bing Maps Key](../getting-started/bing-maps-dev-center-help/getting-a-bing-maps-key.md).