### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/BingMaps/articles/getting-streetside-tiles-from-imagery-metadata.md
+++ b/BingMaps/articles/getting-streetside-tiles-from-imagery-metadata.md
@@ -124,7 +124,7 @@ namespace GridBuilder
 
         public void Print_Grid(string save_file_name)
         {
-            // see https://docs.microsoft.com/dotnet/api/system.drawing.bitmap
+            // see https://learn.microsoft.com/dotnet/api/system.drawing.bitmap
             Bitmap cube_image = new Bitmap(master_size_x, master_size_y);
             Bitmap tmp_image;
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bing Maps Docs
 
-Documentation for the Bing Maps developer APIs. [View the live documentation](https://docs.microsoft.com/bingmaps/)
+Documentation for the Bing Maps developer APIs. [View the live documentation](https://learn.microsoft.com/bingmaps/)
 
 ## Microsoft Open Source Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
