### PR TITLE
Update using-the-rest-services-with-net.md

### DIFF
--- a/BingMaps/rest-services/using-the-rest-services-with-net.md
+++ b/BingMaps/rest-services/using-the-rest-services-with-net.md
@@ -198,6 +198,3 @@ End Function)
   
 ## See Also  
  [Bing Maps REST Service Tips & Tricks](https://blogs.bing.com/maps/2013/02/14/bing-maps-rest-service-tips-tricks/)   
- [Geocoding With the Search Charm (Blog)](https://blogs.bing.com/maps/2013/06/20/geocoding-with-the-search-charm/)   
- [Geocoding with the Search Charm (Code)](https://code.msdn.microsoft.com/Geocoding-with-the-Search-b1dcbf8a)   
- [How to Share Maps Using the Share Charm in Windows Store Apps](https://blogs.msdn.com/b/rbrundritt/archive/2013/11/08/how-to-share-maps-using-the-share-charm-in-windows-store-apps.aspx)


### PR DESCRIPTION
removed everything that references search charm from the See also section.

Geocoding With the Search Charm (Blog)
Geocoding with the Search Charm (Code)
How to Share Maps Using the Share Charm in Windows Store Apps