### PR TITLE
Update directly-accessing-the-bing-maps-tiles.md

### DIFF
--- a/BingMaps/rest-services/directly-accessing-the-bing-maps-tiles.md
+++ b/BingMaps/rest-services/directly-accessing-the-bing-maps-tiles.md
@@ -28,7 +28,7 @@ http://dev.virtualearth.net/REST/V1/Imagery/Metadata/RoadOnDemand?output=json&in
 This will return a response that contains an Image URL property. This URL will look something like this:
 
 ```url
-http://ecn.{subdomain}.tiles.virtualearth.net/tiles/r{quadkey}.jpeg?g=129&mkt={culture}&shading=hill&stl=H
+http://ak.dynamic.{subdomain}.tiles.virtualearth.net/comp/ch/{quadkey}?mkt=en-US&it=G,L&shading=hill&og=2390&n=z
 ```
 
 You can then replace the different parts of the URL to request each tile as needed. The `imageUrlSubdomains` property in the imagery metadata response provides a list of valid subdomain that can be used in the tile URL. Using a different one for each tile request you can increase performance by get around browser URL request limits i.e. many browsers allow up to 8 concurrent requests to the same domain. Using subdomains allows up to 8 requests per subdomain. The culture value can be any value listed in the [Supported Culture Codes](common-parameters-and-types/supported-culture-codes.md) document. The quadkey value can be calculated based on the zoom level and the tile you wish to render. Information on the tile system along with some useful code can be found here:


### PR DESCRIPTION
Hello! I'm a user who is reading BingMap Docs.

Response written in document(`http://ecn.{subdomain}.tiles.virtualearth.net/tiles/r{quadkey}.jpeg?g=129&mkt={culture}&shading=hill&stl=H`) appears when map type is `Road`.

If you use `RoadOnDemand` as the map type as written in the document, you will see the response as below.
```json
{
  "authenticationResultCode": "ValidCredentials",
  "brandLogoUri": "https://dev.virtualearth.net/Branding/logo_powered_by.png",
  "copyright": "Copyright © 2024 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.",
  "resourceSets": [
    {
      "estimatedTotal": 1,
      "resources": [
        {
          "__type": "ImageryMetadata:http://schemas.microsoft.com/search/local/ws/rest/v1",
          "imageHeight": 256,
          "imageUrl": "http://ak.dynamic.{subdomain}.tiles.virtualearth.net/comp/ch/{quadkey}?mkt=en-US&it=G,L&shading=hill&og=2390&n=z",
          "imageUrlSubdomains": [
            "t0",
            "t1",
            "t2",
            "t3"
          ],
          "imageWidth": 256,
          "imageryProviders": [
            {
              "attribution": "© 2024 Microsoft Corporation",
              "coverageAreas": [
                {
                  "bbox": [
                    -90,
                    -180,
                    90,
                    180
                  ],
                  "zoomMax": 21,
                  "zoomMin": 1
                }
              ]
            },
            {
              "attribution": "© 2023 TomTom",
              "coverageAreas": [
                {
                  "bbox": [
                    -90,
                    -180,
                    90,
                    180
                  ],
                  "zoomMax": 21,
                  "zoomMin": 1
                }
              ]
            },
            {
              "attribution": "© 2023 Zenrin",
              "coverageAreas": [
                {
                  "bbox": [
                    23.5,
                    122.5,
                    46.65,
                    151.66
                  ],
                  "zoomMax": 21,
                  "zoomMin": 4
                }
              ]
            },
            {
              "attribution": "© 2023 NavInfo",
              "coverageAreas": [
                {
                  "bbox": [
                    18.566,
                    72.846,
                    54.3085,
                    123.972
                  ],
                  "zoomMax": 21,
                  "zoomMin": 6
                },
                {
                  "bbox": [
                    40.0186,
                    123.972,
                    54.3085,
                    136.0872
                  ],
                  "zoomMax": 21,
                  "zoomMin": 6
                }
              ]
            }
          ],
          "vintageEnd": null,
          "vintageStart": null,
          "zoomMax": 21,
          "zoomMin": 1
        }
      ]
    }
  ],
  "statusCode": 200,
  "statusDescription": "OK",
  "traceId": "b3b8e62b034e8ec46f96d51072277146|PUS000DE22|0.0.0.1"
}
```


I think it would be good to change the response written in the document.

I'd appreciate it if you could tell me if I made a mistake. Thanks:)