### PR TITLE
Distance Matrix Histogram functionality was retired on 9/30/24.

### DIFF
--- a/BingMaps/rest-services/examples/distance-matrix-histogram-example.md
+++ b/BingMaps/rest-services/examples/distance-matrix-histogram-example.md
@@ -17,12 +17,13 @@ ms.service: "bing-maps"
 
 # Distance Matrix Histogram Example
 
-[!INCLUDE [bing-maps-calculate-a-distance-matrix-api-retirement](../../includes/bing-maps-calculate-a-distance-matrix-api-retirement.md)]
-
-Distance Matrix Histogram functionality was retired on 09/30/2024.
-
-
+> [!NOTE]
+> **Bing Maps Distance Matrix Histogram functionality is retired**
+>
+> Bing Maps Distance Matrix Histogram functionality is retired. All implementations using Bing Maps Calculate a Distance Matrix API will need to be updated to use Azure Maps [Route Matrix](/rest/api/maps/route/get-route-matrix) API.
+>
+> Azure Maps is Microsoft's next-generation maps and geospatial services for developers. Azure Maps has many of the same features as Bing Maps for Enterprise, and more. To get started with Azure Maps, create a free [Azure subscription](https://azure.microsoft.com/free) and an [Azure Maps account](/azure/azure-maps/how-to-manage-account-keys#create-a-new-account). For more information about azure Maps, see [Azure Maps Documentation](/azure/azure-maps/). For migration guidance, see [Bing Maps Migration Overview](/azure/azure-maps/migrate-bing-maps-overview).
 
 ## See Also
 
--   [Using the REST Services with .NET](../using-the-rest-services-with-net.md)
+- [Using the REST Services with .NET](../using-the-rest-services-with-net.md)

--- a/BingMaps/rest-services/examples/distance-matrix-histogram-example.md
+++ b/BingMaps/rest-services/examples/distance-matrix-histogram-example.md
@@ -20,7 +20,7 @@ ms.service: "bing-maps"
 > [!NOTE]
 > **Bing Maps Distance Matrix Histogram functionality is retired**
 >
-> Bing Maps Distance Matrix Histogram functionality is no longer available. All implementations using Bing Maps Calculate a Distance Matrix API will need to be updated to use Azure Maps [Route Matrix](/rest/api/maps/route/get-route-matrix) API and, while it is not included, a histogram can be created from those results..
+> Bing Maps Distance Matrix Histogram functionality is no longer available. All implementations using Bing Maps Calculate a Distance Matrix API will need to be updated to use Azure Maps [Route Matrix](/rest/api/maps/route/get-route-matrix) API and, while it is not included, a histogram can be created from those results.
 >
 > Azure Maps is Microsoft's next-generation maps and geospatial services for developers. Azure Maps has many of the same features as Bing Maps for Enterprise, and more. To get started with Azure Maps, create a free [Azure subscription](https://azure.microsoft.com/free) and an [Azure Maps account](/azure/azure-maps/how-to-manage-account-keys#create-a-new-account). For more information about azure Maps, see [Azure Maps Documentation](/azure/azure-maps/). For migration guidance, see [Bing Maps Migration Overview](/azure/azure-maps/migrate-bing-maps-overview).
 

--- a/BingMaps/rest-services/examples/distance-matrix-histogram-example.md
+++ b/BingMaps/rest-services/examples/distance-matrix-histogram-example.md
@@ -20,7 +20,7 @@ ms.service: "bing-maps"
 > [!NOTE]
 > **Bing Maps Distance Matrix Histogram functionality is retired**
 >
-> Bing Maps Distance Matrix Histogram functionality is retired. All implementations using Bing Maps Calculate a Distance Matrix API will need to be updated to use Azure Maps [Route Matrix](/rest/api/maps/route/get-route-matrix) API.
+> Bing Maps Distance Matrix Histogram functionality is no longer available. All implementations using Bing Maps Calculate a Distance Matrix API will need to be updated to use Azure Maps [Route Matrix](/rest/api/maps/route/get-route-matrix) API and, while it is not included, a histogram can be created from those results..
 >
 > Azure Maps is Microsoft's next-generation maps and geospatial services for developers. Azure Maps has many of the same features as Bing Maps for Enterprise, and more. To get started with Azure Maps, create a free [Azure subscription](https://azure.microsoft.com/free) and an [Azure Maps account](/azure/azure-maps/how-to-manage-account-keys#create-a-new-account). For more information about azure Maps, see [Azure Maps Documentation](/azure/azure-maps/). For migration guidance, see [Bing Maps Migration Overview](/azure/azure-maps/migrate-bing-maps-overview).
 

--- a/BingMaps/rest-services/toc.yml
+++ b/BingMaps/rest-services/toc.yml
@@ -139,8 +139,6 @@ items:
       href: examples/distance-matrix-asynchronous-example.md
     - name: Distance Matrix Example
       href: examples/distance-matrix-example.md
-    - name: Distance Matrix Histogram Example
-      href: examples/distance-matrix-histogram-example.md
     - name: Driving Route Example
       href: examples/driving-route-example.md
     - name: Driving Route Using Tolerances Example


### PR DESCRIPTION
Updated retirement banner and removed link to example from the TOC.

Note that there are redirects to this example, and no good place to redirect those links to, best to just explain in the unlikely event a customer finds themselves being redirected to this page. There are no Bing Maps articles that link to this article.