### PR TITLE
Changed URL for map control addresses to use SSL.

### DIFF
--- a/BingMaps/articles/custom-map-styles-in-bing-maps.md
+++ b/BingMaps/articles/custom-map-styles-in-bing-maps.md
@@ -62,7 +62,7 @@ The Bing Maps V8 control has a new map option called `customMapStyle` which can 
             });
         }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap"></div>

--- a/BingMaps/v8-web-control/creating-and-hosting-map-controls/creating-a-basic-map-control.md
+++ b/BingMaps/v8-web-control/creating-and-hosting-map-controls/creating-a-basic-map-control.md
@@ -48,7 +48,7 @@ Displaying the default map, which includes all of the navigation functionality, 
 3. In the header section or the body of the page add a reference to the map control script. You specify your Bing Maps key as part of the map script URL.  The map control can be loaded asynchronously by specifying a callback function in the script URL and by adding "async defer" to the script tag as follows:
 
     ```html
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
     ```
 
     To use SSL, change http to https:
@@ -109,7 +109,7 @@ The following is the full code required for loading a map asynchronously.
 
     <!-- Reference to the Bing Maps SDK -->
     <script type='text/javascript'
-            src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' 
+            src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' 
             async defer></script>
     
     <script type='text/javascript'>

--- a/BingMaps/v8-web-control/creating-and-hosting-map-controls/creating-a-basic-map-control.md
+++ b/BingMaps/v8-web-control/creating-and-hosting-map-controls/creating-a-basic-map-control.md
@@ -51,14 +51,6 @@ Displaying the default map, which includes all of the navigation functionality, 
     <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
     ```
 
-    To use SSL, change http to https:
-
-    ```html
-    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
-    ```
-
-    This will result in the browser inheriting the protocol from the website and automatically selecting HTTP or HTTPS as needed.
-
     > [!TIP]
     > If you need to call the control without the use of cookies, use the Virtual Earth endpoint rather than the Bing endpoint. To use Virtual Earth endpoint, you would change the `src=` in the URLs that start with `www.bing.com` to start with `sdk.virtualearth.net`.
 

--- a/BingMaps/v8-web-control/creating-and-hosting-map-controls/setting-map-control-parameters.md
+++ b/BingMaps/v8-web-control/creating-and-hosting-map-controls/setting-map-control-parameters.md
@@ -28,7 +28,7 @@ To add a parameter to the map control src URL, add a `?`, the parameter, and set
 The following example sets the map control URL such that it triggers a callback function called GetMap after the script has finished loading. It also loads the experimental branch of the map control in Italian.
 
 ```html
-<script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&branch=experimental&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+<script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&branch=experimental&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 ```
 
 ## Parameters
@@ -49,7 +49,7 @@ The Bing Maps V8 Map Control automatically detects the users language and cultur
 Here is an example of Bing Maps with the language parameter set to "fr" and the locale parameter set to "fr-FR".
 
 ```html
-<script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&setMkt=fr-FR&setLang=fr' async defer></script>
+<script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&setMkt=fr-FR&setLang=fr' async defer></script>
 ```
 
 The resulting map looks like this:

--- a/BingMaps/v8-web-control/map-control-concepts/autosuggest-module-examples/default-autosuggest-user-interface-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/autosuggest-module-examples/default-autosuggest-user-interface-example.md
@@ -49,7 +49,7 @@ The following code example shows how to add the default autosuggest functionalit
         map.setView({ bounds: result.bestView });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id='searchBoxContainer'>

--- a/BingMaps/v8-web-control/map-control-concepts/autosuggest-module-examples/filling-in-an-address-form-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/autosuggest-module-examples/filling-in-an-address-form-example.md
@@ -70,7 +70,7 @@ This example shows how to use the selected result from the default autosuggest U
             width:265px;
         }
     </style>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id='searchBoxContainer'>

--- a/BingMaps/v8-web-control/map-control-concepts/clustering-module-examples/basic-clustering-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/clustering-module-examples/basic-clustering-example.md
@@ -44,7 +44,7 @@ The following code example loads the Clustering module and then generates 1,000 
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/clustering-module-examples/clusters-with-a-list-and-linking.md
+++ b/BingMaps/v8-web-control/map-control-concepts/clustering-module-examples/clusters-with-a-list-and-linking.md
@@ -128,7 +128,7 @@ This example shows how to dynamically create a list of the pushpins that are cur
 	    });
 	}
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative; width:600px; height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/clustering-module-examples/customizing-clustered-pushpins.md
+++ b/BingMaps/v8-web-control/map-control-concepts/clustering-module-examples/customizing-clustered-pushpins.md
@@ -100,7 +100,7 @@ In this code example, instead of simply using a custom image to represent a clus
 	    });
 	}
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/clustering-module-examples/zoom-into-clusters.md
+++ b/BingMaps/v8-web-control/map-control-concepts/clustering-module-examples/zoom-into-clusters.md
@@ -70,7 +70,7 @@ This example adds a click event to the clustered pushpins. When clicked, a bound
 	    }
 	}
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/custom-overlays/dynamic-canvas-overlay.md
+++ b/BingMaps/v8-web-control/map-control-concepts/custom-overlays/dynamic-canvas-overlay.md
@@ -181,7 +181,7 @@ Implementing this canvas overlay is fairly easy and in this example we will simp
         });
     }    
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:800px;height:600px;"></div>
@@ -345,7 +345,7 @@ The following is the source code for the complete HTML page that includes the of
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:800px;height:600px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/custom-overlays/html-pushpin-overlay.md
+++ b/BingMaps/v8-web-control/map-control-concepts/custom-overlays/html-pushpin-overlay.md
@@ -170,7 +170,7 @@ The following code shows how to implement this module by adding a simple HTML el
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/custom-overlays/simple-static-overlay.md
+++ b/BingMaps/v8-web-control/map-control-concepts/custom-overlays/simple-static-overlay.md
@@ -113,7 +113,7 @@ This example creates a simple overlay that consists of 4 buttons that allow you 
         map.setView({ center: map.tryPixelToLocation(cp) });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:800px;height:600px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/custom-overlays/topography-overlay.md
+++ b/BingMaps/v8-web-control/map-control-concepts/custom-overlays/topography-overlay.md
@@ -91,7 +91,7 @@ This example creates a custom overlay that stretches an image such that the corn
         map.layers.insert(overlay);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:800px;height:600px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/directions-module-examples/calculate-driving-directions.md
+++ b/BingMaps/v8-web-control/map-control-concepts/directions-module-examples/calculate-driving-directions.md
@@ -55,7 +55,7 @@ The following example shows how to calculate driving directions from “Seattle,
             });
         }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:800px;height:600px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/directions-module-examples/calculate-transit-directions.md
+++ b/BingMaps/v8-web-control/map-control-concepts/directions-module-examples/calculate-transit-directions.md
@@ -66,7 +66,7 @@ The following example shows how to calculate transit directions from “Redmond,
             });
         }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:800px;height:600px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/directions-module-examples/directions-input-panel.md
+++ b/BingMaps/v8-web-control/map-control-concepts/directions-module-examples/directions-input-panel.md
@@ -69,7 +69,7 @@ The following example shows how to display the built in input panel for calculat
             float:left;
         }
     </style>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div class="directionsContainer">

--- a/BingMaps/v8-web-control/map-control-concepts/directions-module-examples/directions-module-events.md
+++ b/BingMaps/v8-web-control/map-control-concepts/directions-module-examples/directions-module-events.md
@@ -84,7 +84,7 @@ This example shows how to use events with the directions manager. A route from â
             alert('Error: ' + e.message + '\r\nResponse Code: ' + e.responseCode)
         }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:800px;height:600px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/drawing-tools-module-examples/display-drawing-toolbar-on-map.md
+++ b/BingMaps/v8-web-control/map-control-concepts/drawing-tools-module-examples/display-drawing-toolbar-on-map.md
@@ -46,7 +46,7 @@ This example shows how to add a drawing toolbar to the map so that the user can 
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/drawing-tools-module-examples/drawingmanager-events.md
+++ b/BingMaps/v8-web-control/map-control-concepts/drawing-tools-module-examples/drawingmanager-events.md
@@ -60,7 +60,7 @@ The example adds a bunch of events to the drawing manager that is created by the
         setTimeout(function () { document.getElementById(id).style.background = 'white'; }, 1000);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/drawing-tools-module-examples/edit-an-existing-shape.md
+++ b/BingMaps/v8-web-control/map-control-concepts/drawing-tools-module-examples/edit-an-existing-shape.md
@@ -44,7 +44,7 @@ This example shows how to take an existing polygon and enable editing on it.
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/drawing-tools-module-examples/get-shapes-from-drawingmanager.md
+++ b/BingMaps/v8-web-control/map-control-concepts/drawing-tools-module-examples/get-shapes-from-drawingmanager.md
@@ -52,7 +52,7 @@ This example shows how to get all the shapes that are in the drawing manager at 
         }
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div><br/>

--- a/BingMaps/v8-web-control/map-control-concepts/event-examples/index.md
+++ b/BingMaps/v8-web-control/map-control-concepts/event-examples/index.md
@@ -65,7 +65,7 @@ The following example shows how to add a viewchange event to the map and have th
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div><br/>

--- a/BingMaps/v8-web-control/map-control-concepts/geojson-module-examples/read-geojson-from-the-web-using-jsonp-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/geojson-module-examples/read-geojson-from-the-web-using-jsonp-example.md
@@ -45,7 +45,7 @@ In this example we will use the USGS Earthquake REST service to load in recent e
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:1200px;height:800px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/geojson-module-examples/read-local-geojson-object-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/geojson-module-examples/read-local-geojson-object-example.md
@@ -64,7 +64,7 @@ The following code example takes a locally defined GeoJSON object and parses it 
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/geojson-module-examples/read-same-domain-geojson-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/geojson-module-examples/read-same-domain-geojson-example.md
@@ -46,7 +46,7 @@ The following code example takes a URL to a GeoJSON file that is hosted on the s
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:1000px;height:800px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/geojson-module-examples/write-bing-maps-shape-as-geojson-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/geojson-module-examples/write-bing-maps-shape-as-geojson-example.md
@@ -61,7 +61,7 @@ This example takes a Bing Maps shape and uses the GeoJSON module to generate a G
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/heat-map-module-examples/basic-heat-map-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/heat-map-module-examples/basic-heat-map-example.md
@@ -43,7 +43,7 @@ The following example loads 1,000 random locations into a heat map that are with
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/heat-map-module-examples/customized-heat-map-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/heat-map-module-examples/customized-heat-map-example.md
@@ -56,7 +56,7 @@ This example loads 50,000 random locations into the heat map layer. The heat map
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/heat-map-module-examples/render-geojson-as-heat-map.md
+++ b/BingMaps/v8-web-control/map-control-concepts/heat-map-module-examples/render-geojson-as-heat-map.md
@@ -46,7 +46,7 @@ This code sample loads in earthquake data for the last 30 days from the United S
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/infoboxes/basic-infobox-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/infoboxes/basic-infobox-example.md
@@ -47,7 +47,7 @@ The following code shows how to add an infobox with a title and description to t
         infobox.setMap(map);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/infoboxes/custom-html-infobox.md
+++ b/BingMaps/v8-web-control/map-control-concepts/infoboxes/custom-html-infobox.md
@@ -70,7 +70,7 @@ For many apps the default infobox and the various options for customizing it wor
                 margin-bottom: 5px;
             }
     </style>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/infoboxes/expanding-tooltip-infobox.md
+++ b/BingMaps/v8-web-control/map-control-concepts/infoboxes/expanding-tooltip-infobox.md
@@ -111,7 +111,7 @@ Often infoboxes are displayed when a user clicks or hovers over a pushpin. Anoth
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/infoboxes/infobox-when-pushpin-clicked.md
+++ b/BingMaps/v8-web-control/map-control-concepts/infoboxes/infobox-when-pushpin-clicked.md
@@ -71,7 +71,7 @@ One of the most common scenarios where an infobox is displayed, is when a user c
         }
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/infoboxes/infobox-when-shape-clicked.md
+++ b/BingMaps/v8-web-control/map-control-concepts/infoboxes/infobox-when-shape-clicked.md
@@ -71,7 +71,7 @@ Often it is useful to be able to display an infobox when any `IPrimitive` shape;
         }
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/infoboxes/infobox-with-options.md
+++ b/BingMaps/v8-web-control/map-control-concepts/infoboxes/infobox-with-options.md
@@ -58,7 +58,7 @@ This example shows how to create and infobox with the options that hide the poin
         infobox.setMap(map);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/infoboxes/multiple-pushpins-and-infoboxes.md
+++ b/BingMaps/v8-web-control/map-control-concepts/infoboxes/multiple-pushpins-and-infoboxes.md
@@ -74,7 +74,7 @@ When you have a lot of pushpins and only want to show one infobox at a time, the
         }
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/layers/animated-weather-radar-map.md
+++ b/BingMaps/v8-web-control/map-control-concepts/layers/animated-weather-radar-map.md
@@ -62,7 +62,7 @@ This example uses the [AnimatedTileLayer](../../map-control-api/animatedtilelaye
         map.layers.insert(animatedLayer);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/layers/animatedtilelayer-events.md
+++ b/BingMaps/v8-web-control/map-control-concepts/layers/animatedtilelayer-events.md
@@ -91,7 +91,7 @@ This example uses the `onFrameLoaded` event of the [AnimatedTileLayer](../../map
             text-align:center;
         }
     </style>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/layers/basic-tile-layer-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/layers/basic-tile-layer-example.md
@@ -68,7 +68,7 @@ In order to add a tile layer to the map, you first need a source of map tile dat
             map.layers.insert(katrinaTileLayer);
         }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/layers/controlling-an-animatedtilelayer.md
+++ b/BingMaps/v8-web-control/map-control-concepts/layers/controlling-an-animatedtilelayer.md
@@ -62,7 +62,7 @@ This example shows how to control an [AnimatedTileLayer](../../map-control-api/a
         map.layers.insert(animatedLayer);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/layers/data-layer-events.md
+++ b/BingMaps/v8-web-control/map-control-concepts/layers/data-layer-events.md
@@ -61,7 +61,7 @@ Many applications add mouse events to shapes by looping through each shape and a
         setTimeout(function () { document.getElementById(id).style.background = 'white'; }, 1000);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/layers/wms-tile-layer-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/layers/wms-tile-layer-example.md
@@ -54,7 +54,7 @@ This example shows how to take the [NOAA Base Reflective Weather Radar WMS servi
             map.layers.insert(NOAAWeatherRadar);
         }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/basic-polygon-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/basic-polygon-example.md
@@ -52,7 +52,7 @@ The following code creates a simple polygon that has a red outline and a semi-tr
         map.entities.push(polygon);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/basic-polyline-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/basic-polyline-example.md
@@ -47,7 +47,7 @@ The following code creates a polyline that is red in color, has a thickness of 3
         map.entities.push(line);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/polygon-events.md
+++ b/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/polygon-events.md
@@ -55,7 +55,7 @@ This example attaches several mouse events to a polygon. When these events fire 
         setTimeout(function () { document.getElementById(id).style.background = 'white'; }, 1000);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/polygons-with-holes-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/polygons-with-holes-example.md
@@ -63,7 +63,7 @@ The following code is an example that creates a complex polygon that has a hole 
         map.entities.push(polygon);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/polyline-events.md
+++ b/BingMaps/v8-web-control/map-control-concepts/map-shapes-polylines-and-polygons/polyline-events.md
@@ -55,7 +55,7 @@ This example attaches several mouse events to a polyline. When these events fire
         setTimeout(function () { document.getElementById(id).style.background = 'white'; }, 1000);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/map/change-the-map-view.md
+++ b/BingMaps/v8-web-control/map-control-concepts/map/change-the-map-view.md
@@ -39,7 +39,7 @@ There are two different ways to change the map view. One way is to use the **set
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/map/customize-map-options-on-load.md
+++ b/BingMaps/v8-web-control/map-control-concepts/map/customize-map-options-on-load.md
@@ -30,7 +30,7 @@ As mentioned before, you can customize the map when loading it. Use the followin
 
     <!-- Reference to the Bing Maps SDK -->
     <script type='text/javascript'
-            src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+            src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
     
     <script type='text/javascript'>
     function GetMap()

--- a/BingMaps/v8-web-control/map-control-concepts/map/map-events.md
+++ b/BingMaps/v8-web-control/map-control-concepts/map/map-events.md
@@ -60,7 +60,7 @@ This example shows how all the different events for the map work by highlighting
         setTimeout(function () { document.getElementById(id).style.background = 'white'; }, 1000);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/modular-framework/creating-custom-modules.md
+++ b/BingMaps/v8-web-control/map-control-concepts/modular-framework/creating-custom-modules.md
@@ -89,7 +89,7 @@ If this module was stored saved in a folder called js and a file called MyModule
             });
         }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/point-compression-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/point-compression-example.md
@@ -63,7 +63,7 @@ In this example the encoded string “x90uhio4sQmhuGwxrGz8sGp-zP5ooKpx9Eiz7Ip2vF
         }
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/changing-the-color-of-the-default-pushpin.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/changing-the-color-of-the-default-pushpin.md
@@ -45,7 +45,7 @@ The default pushpin works well for most applications, but sometimes its useful t
         map.entities.push(pin);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-base64-image-pushpin-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-base64-image-pushpin-example.md
@@ -54,7 +54,7 @@ To create a custom pushpin out of this base64 image string, simply pass it into 
         map.entities.push(pin);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-canvas-pushpin-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-canvas-pushpin-example.md
@@ -78,7 +78,7 @@ In this example, a function is created that takes in a heading and draws an arro
         return c.toDataURL();
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-image-pushpin-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-image-pushpin-example.md
@@ -48,7 +48,7 @@ You can use the following code to create a pushpin using the image of the sun. A
         map.entities.push(pin);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-inline-svg-pushpin-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-inline-svg-pushpin-example.md
@@ -51,7 +51,7 @@ To create a custom pushpin out of this SVG, convert the SVG into a string and th
         map.entities.push(pin);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-svg-file-pushpin-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/custom-svg-file-pushpin-example.md
@@ -65,7 +65,7 @@ To create a custom pushpin out of this SVG, simply pass the path the SVG file in
         map.entities.push(pin);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/default-pushpin-with-text-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/default-pushpin-with-text-example.md
@@ -47,7 +47,7 @@ The following code creates a pushpin at the center of the map that has a text va
         map.entities.push(pin);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/dynamically-create-svg-pushpin-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/dynamically-create-svg-pushpin-example.md
@@ -58,7 +58,7 @@ This code sample shows how to dynamically create SVG circles for pushpins icons.
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/font-based-pushpins.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/font-based-pushpins.md
@@ -29,7 +29,7 @@ One great source for pushpin icons is font based glyphs. This example shows how 
     <meta charset="utf-8" />
     <link href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" />
 
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
     
     <script type='text/javascript' charset="utf-8">
     function GetMap() {

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/image-and-canvas-pushpin-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/image-and-canvas-pushpin-example.md
@@ -72,7 +72,7 @@ Note that the circular part of the pushpin has some transparency. By drawing a c
         img.src = 'images/TransparentPushpin.png';
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/pushpin-events-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/pushpin-events-example.md
@@ -55,7 +55,7 @@ This example attaches several mouse events to a pushpin. When these events are t
         setTimeout(function () { document.getElementById(id).style.background = 'white'; }, 1000);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:800px;height:600px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/pushpins/pushpin-hover-style.md
+++ b/BingMaps/v8-web-control/map-control-concepts/pushpins/pushpin-hover-style.md
@@ -57,7 +57,7 @@ Creating a custom pushpin is great, but having the style change when users inter
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:800px;height:600px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/search-module-examples/basic-geocode-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/search-module-examples/basic-geocode-example.md
@@ -70,7 +70,7 @@ The following code sample shows how to make a geocode request using the Search m
         }
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/search-module-examples/basic-reverse-geocode-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/search-module-examples/basic-reverse-geocode-example.md
@@ -67,7 +67,7 @@ The following code sample shows how to make a reverse geocode request using the 
         }
     }
     </script>    
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/search-module-examples/user-input-geocode-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/search-module-examples/user-input-geocode-example.md
@@ -103,7 +103,7 @@ This code sample displays a search textbox and button along with a map. When the
         searchManager.geocode(searchRequest);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <input id='searchTbx' type='text'/>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/filter-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/filter-example.md
@@ -43,7 +43,7 @@ This example loads the Spatial Data Services module on its own as a map isn't re
     <meta charset="utf-8" />
 
     <script type='text/javascript'
-            src='http://www.bing.com/api/maps/mapcontrol?callback=RunTests'
+            src='https://www.bing.com/api/maps/mapcontrol?callback=RunTests'
             async defer></script>
 
     <script type='text/javascript'>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/geodata-api/load-multiple-boundaries-geodata-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/geodata-api/load-multiple-boundaries-geodata-example.md
@@ -61,7 +61,7 @@ Displaying the boundary of a single location is useful, but sometimes you need t
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/geodata-api/load-single-boundary-geodata-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/geodata-api/load-single-boundary-geodata-example.md
@@ -57,7 +57,7 @@ This examples renders a PopulatedPlace (city, town) boundary for the Location th
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/geodata-api/search-boundary-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/geodata-api/search-boundary-example.md
@@ -113,7 +113,7 @@ However, what if you want to get the boundary of a location and don't know what 
         }
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <input type="text" id="inputTbx"/>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/along-a-route-search.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/along-a-route-search.md
@@ -165,7 +165,7 @@ This example shows how to search for locations along a route. It uses the built-
             float: left;
         }
     </style>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div class="directionsContainer">

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/basic-intersection-search-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/basic-intersection-search-example.md
@@ -67,7 +67,7 @@ This example shows how to make a simple intersection query against a data source
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/choropleth-map-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/choropleth-map-example.md
@@ -151,7 +151,7 @@ This code example retrieves [US state boundaries from a Spatial Data Source](../
             float:right;
         }
     </style>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div class="mapContainer">

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/find-by-property-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/find-by-property-example.md
@@ -62,7 +62,7 @@ One of the simplest ways to query a data source is to do a property based search
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/find-nearby-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/find-nearby-example.md
@@ -69,7 +69,7 @@ One of the most common types of searches done with a map is a nearby search, als
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="map" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/paged-search-results-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-data-services-module-examples/query-api/paged-search-results-example.md
@@ -150,7 +150,7 @@ This code example takes a data source and performs an initial radial search of 1
         }
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-math-module-examples/basic-core-spatial-math-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-math-module-examples/basic-core-spatial-math-example.md
@@ -73,7 +73,7 @@ The following example shows how to use a number of the core Spatial Math functio
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div><br/>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-math-module-examples/calculate-tile-bounds.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-math-module-examples/calculate-tile-bounds.md
@@ -67,7 +67,7 @@ This example uses some of the Tile math functions in the Spatial Math library. T
         }
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-math-module-examples/geolocation-accuracy-circle-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-math-module-examples/geolocation-accuracy-circle-example.md
@@ -54,7 +54,7 @@ When using the HTML Geolocation library, it may be useful to be able to display 
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/spatial-math-module-examples/geometry-binary-operations.md
+++ b/BingMaps/v8-web-control/map-control-concepts/spatial-math-module-examples/geometry-binary-operations.md
@@ -102,7 +102,7 @@ This example loads a map with two random polygons displayed on it. Below the map
     }
     </script>
     
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?branch=experimental&callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?branch=experimental&callback=GetMap' async defer></script>
 </head>
 <body>
     <div id='myMap' style='position:relative;width:600px;height:400px;'></div>

--- a/BingMaps/v8-web-control/map-control-concepts/test-data-generator-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/test-data-generator-example.md
@@ -43,7 +43,7 @@ The following code sample shows how to create two random polygons that have a sc
         map.entities.push(polygons);
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/traffic-module-examples.md
+++ b/BingMaps/v8-web-control/map-control-concepts/traffic-module-examples.md
@@ -48,7 +48,7 @@ This examples shows how to display traffic data on top of the map.
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap&key=[YOUR_BING_MAPS_KEY]' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/user-location/continuously-tracking-a-user-location-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/user-location/continuously-tracking-a-user-location-example.md
@@ -67,7 +67,7 @@ This example shows how to monitor the user’s location and update the position 
         map.entities.clear();
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div><br/>

--- a/BingMaps/v8-web-control/map-control-concepts/user-location/displaying-a-user-location-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/user-location/displaying-a-user-location-example.md
@@ -48,7 +48,7 @@ This example shows how to request the user’s location and then display it on t
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/well-known-text-examples/well-known-text-read-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/well-known-text-examples/well-known-text-read-example.md
@@ -44,7 +44,7 @@ This example shows how to parse a Well Known Text string value into a Bing Maps 
         });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>

--- a/BingMaps/v8-web-control/map-control-concepts/well-known-text-examples/well-known-text-write-example.md
+++ b/BingMaps/v8-web-control/map-control-concepts/well-known-text-examples/well-known-text-write-example.md
@@ -62,7 +62,7 @@ This code example shows how to convert a Bing Maps shape into a Well Known Text 
             });
     }
     </script>
-    <script type='text/javascript' src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
+    <script type='text/javascript' src='https://www.bing.com/api/maps/mapcontrol?callback=GetMap' async defer></script>
 </head>
 <body>
     <div id="myMap" style="position:relative;width:600px;height:400px;"></div>


### PR DESCRIPTION
Changed: 

> 'http://www.bing.com/api/maps/mapcontrol ...

to:

> 'https://www.bing.com/api/maps/mapcontrol ...

and removed the example in [Creating a Basic Map Control - Microsoft Bing Maps | Microsoft Learn](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fbingmaps%2Fv8-web-control%2Fcreating-and-hosting-map-controls%2Fcreating-a-basic-map-control&data=05%7C02%7Cv-munksteven%40microsoft.com%7C77667eb2c40d4eba9ffb08ddfd280354%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638945070488939265%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=fHdJs0kIbP%2B8J01X6vHcUiDvNJmbYurq1HQSyPWpOCk%3D&reserved=0) that demonstrated using  the non-SSL URL.

<img width="1818" height="946" alt="image" src="https://github.com/user-attachments/assets/96173259-1fa8-41d9-afe0-da743e662541" />
